### PR TITLE
Clarify Pool-generated StorageClass parameters, drop dead ndcs/npcs

### DIFF
--- a/docs/kubernetes/installation/k8s-storage-plane.md
+++ b/docs/kubernetes/installation/k8s-storage-plane.md
@@ -204,8 +204,16 @@ Once the pool is active, the operator automatically creates a StorageClass named
 `simplyblock-<namespace>-<clusterName>-<poolName>`. In this example, the StorageClass is called
 `simplyblock-simplyblock-cluster-production-pool`.
 
-The StorageClass is automatically removed when the storage pool is deleted. For full details and customization options
-are available at [Simplyblock Operator: Storage Pool](../../reference/operator/reference.md#storagepool).
+`cluster_id` and `pool_name` are set from the storage pool and cannot be overridden. The remaining StorageClass
+parameters are copied from `spec.storageClassParameters`. See
+[Storage Class: StorageClass Created by a Storage Pool](../usage/storage-class.md#storageclass-created-by-a-storage-pool)
+for the full parameter mapping.
+
+A StorageClass's parameters cannot be changed after creation, so `spec.storageClassParameters` is immutable
+once the storage pool is created. A new storage pool is required to provision volumes with different defaults.
+
+The StorageClass is automatically removed when the storage pool is deleted. Full details and customization
+options are available at [Simplyblock Operator: Storage Pool](../../reference/operator/reference.md#storagepool).
 
 ```bash title="Check the StorageClass"
 kubectl get storageclass simplyblock-simplyblock-production-my-pool

--- a/docs/kubernetes/usage/storage-class.md
+++ b/docs/kubernetes/usage/storage-class.md
@@ -33,6 +33,26 @@ always set from the storage pool and cannot be overridden. The rest of the param
 `StoragePool.spec.storageClassParameters`. Defaults for each field are listed at
 [Simplyblock Operator: StorageClassParameters](../../reference/operator/reference.md#storageclassparameters).
 
+The CRD fields carry camel case names and are written to the StorageClass under the parameter names of the CSI driver:
+
+| `storageClassParameters` Field | StorageClass Parameter      |
+|--------------------------------|-----------------------------|
+| `qosRwIops`                    | `qos_rw_iops`               |
+| `qosRwMbytes`                  | `qos_rw_mbytes`             |
+| `qosRMbytes`                   | `qos_r_mbytes`              |
+| `qosWMbytes`                   | `qos_w_mbytes`              |
+| `compression`                  | `compression`               |
+| `encryption`                   | `encryption`                |
+| `replicate`                    | `replicate`                 |
+| `lvolPriorityClass`            | `lvol_priority_class`       |
+| `fabric`                       | `fabric`                    |
+| `maxNamespacePerSubsys`        | `max_namespace_per_subsys`  |
+| `tune2fsReservedBlocks`        | `tune2fs_reserved_blocks`   |
+| `filesystem`                   | `csi.storage.k8s.io/fstype` |
+
+For a storage pool with `dhchap` enabled and `allowedNodes` set, `dhchap_node_label` is added by the operator as well,
+and the generated StorageClass is restricted to those nodes through its allowed topologies.
+
 Kubernetes does not allow the `parameters` of a StorageClass to be changed after creation, so
 `StoragePool.spec.storageClassParameters` is immutable once the storage pool is created. There is no supported way to
 reconfigure the generated StorageClass afterward. A new storage pool has to be created to provision volumes with
@@ -92,7 +112,7 @@ If `namespace-volumes` is set to `yes`, the number of namespaces per subsystem h
 | qos_w_mbytes              | int        | Defines the maximum write throughput in megabytes reserved for a logical volume of this storage class. A zero (0) means no maximum.                                                            | true     | 0        |
 | compression               | bool       | Defines if the logical volume of this storage class will be stored compressed or not.                                                                                                          | true     | false    |
 | encryption                | bool       | Defines if the logical volume of this storage class will be encrypted or not.                                                                                                                  | true     | false    |
-| replicate                 | bool       | Defines if the logical volumes of this storage class are replicated.                                                                                                                           | true     | false    |
+| replicate                 | bool       | Defines if the logical volume of this storage class will be replicated or not.                                                                                                                 | true     | false    |
 | lvol_priority_class       | int        | Defines the priority class of a logical volume of this storage class.                                                                                                                          | true     | 0        |
 | max_namespace_per_subsys  | int        | Defines the number of namespaces per NVMe subsystem.                                                                                                                                           | true     | 1        |
 | tune2fs_reserved_blocks   | int        | Defines the number of reserved blocks for tune2fs operations.                                                                                                                                  | true     | 0        |

--- a/docs/kubernetes/usage/storage-class.md
+++ b/docs/kubernetes/usage/storage-class.md
@@ -24,6 +24,20 @@ simplyblock control plane to provision a logical volume matching the requested s
 the complexity of volume creation and ensures that workloads running in Kubernetes receive high-performance, resilient
 block storage directly backed by simplyblock.
 
+## StorageClass Created by a Storage Pool
+
+A StorageClass named `simplyblock-<namespace>-<clusterName>-<poolName>` is created automatically by the operator once
+a `StoragePool` resource becomes active, as described in
+[Create a Storage Pool](../installation/k8s-storage-plane.md#create-a-storage-pool). `cluster_id` and `pool_name` are
+always set from the storage pool and cannot be overridden. The rest of the parameters are copied from
+`StoragePool.spec.storageClassParameters`. Defaults for each field are listed at
+[Simplyblock Operator: StorageClassParameters](../../reference/operator/reference.md#storageclassparameters).
+
+Kubernetes does not allow the `parameters` of a StorageClass to be changed after creation, so
+`StoragePool.spec.storageClassParameters` is immutable once the storage pool is created. There is no supported way to
+reconfigure the generated StorageClass afterward. A new storage pool has to be created to provision volumes with
+different defaults.
+
 ## Example Usage
 
 A typical simplyblock StorageClass contains the name of the storage class, a filesystem type to automatically format
@@ -47,8 +61,8 @@ allowVolumeExpansion: true
 
 ## StorageClass Parameters
 
-Each cluster has a default schema, but each volume can optionally use an alternative schema. However, the schema must
-"fit" into the cluster, meaning `n+k` must be equal to (or better smaller) than the number of nodes in the cluster.
+The erasure coding schema (the number of data and parity chunks per stripe) is set once at cluster creation and
+applies to all volumes in the cluster. It cannot be configured per volume or through a StorageClass.
 
 See the [Erasure Coding Configuration](../../deployment-preparation/erasure-coding-scheme.md) for more details.
 
@@ -78,8 +92,7 @@ If `namespace-volumes` is set to `yes`, the number of namespaces per subsystem h
 | qos_w_mbytes              | int        | Defines the maximum write throughput in megabytes reserved for a logical volume of this storage class. A zero (0) means no maximum.                                                            | true     | 0        |
 | compression               | bool       | Defines if the logical volume of this storage class will be stored compressed or not.                                                                                                          | true     | false    |
 | encryption                | bool       | Defines if the logical volume of this storage class will be encrypted or not.                                                                                                                  | true     | false    |
-| distr_ndcs                | int        | Defines the number of data chunks for the erasure coding scheme.                                                                                                                               | true     | 1        |
-| distr_npcs                | int        | Defines the number of parity chunks for the erasure coding scheme.                                                                                                                             | true     | 1        |
+| replicate                 | bool       | Defines if the logical volumes of this storage class are replicated.                                                                                                                           | true     | false    |
 | lvol_priority_class       | int        | Defines the priority class of a logical volume of this storage class.                                                                                                                          | true     | 0        |
 | max_namespace_per_subsys  | int        | Defines the number of namespaces per NVMe subsystem.                                                                                                                                           | true     | 1        |
 | tune2fs_reserved_blocks   | int        | Defines the number of reserved blocks for tune2fs operations.                                                                                                                                  | true     | 0        |


### PR DESCRIPTION
## Summary
- Document that `Pool.spec.storageClassParameters` is copied verbatim into the auto-generated StorageClass and is immutable once the pool is created (simplyblock/simplyblock-operator#409).
- Remove `distr_ndcs`/`distr_npcs` from the StorageClass parameter reference — the CSI driver dropped per-volume erasure coding overrides (simplyblock/simplyblock-csi#440); the schema is fixed at cluster creation, matching what's already documented in cluster deployment options and the Linux initiators guide.

## Test plan
- [x] `./scripts/quality-gate.sh` (voice, prose, terminology, American English, punctuation, mkdocs syntax) passes clean for both changed files