### PR TITLE
docs: object limits and the cluster alerts endpoint

### DIFF
--- a/docs/kubernetes/operations/monitoring/alerts.md
+++ b/docs/kubernetes/operations/monitoring/alerts.md
@@ -33,3 +33,18 @@ The following pre-defined alerts are available:
 
 It is possible to configure the Slack webhook for alerting during cluster creation or to modify it at a later point in
 time.
+
+## Querying Alerts Directly
+
+The pre-defined alerts above are evaluated by Grafana and pushed to a contact point. The control plane also
+exposes the currently active conditions as a REST resource, which answers what is wrong right now without going
+through Grafana:
+
+```plain title="Alerts endpoint"
+GET /api/v2/clusters/<CLUSTER_UUID>/alerts/
+```
+
+It suppresses the states an operator caused on purpose, such as a node that was shut down or a device that was
+removed, and it drops each alert as soon as the condition ends. See
+[Alerts Endpoint](../../../reference/api/alerts.md) for the full list of alert kinds, the query parameters, and
+how to forward the alerts to a Slack webhook.

--- a/docs/non-kubernetes/operations/monitoring/alerts.md
+++ b/docs/non-kubernetes/operations/monitoring/alerts.md
@@ -33,3 +33,18 @@ The following pre-defined alerts are available:
 
 It is possible to configure the Slack webhook for alerting during cluster creation or to modify it at a later point in
 time.
+
+## Querying Alerts Directly
+
+The pre-defined alerts above are evaluated by Grafana and pushed to a contact point. The control plane also
+exposes the currently active conditions as a REST resource, which answers what is wrong right now without going
+through Grafana:
+
+```plain title="Alerts endpoint"
+GET /api/v2/clusters/<CLUSTER_UUID>/alerts/
+```
+
+It suppresses the states an operator caused on purpose, such as a node that was shut down or a device that was
+removed, and it drops each alert as soon as the condition ends. See
+[Alerts Endpoint](../../../reference/api/alerts.md) for the full list of alert kinds, the query parameters, and
+how to forward the alerts to a Slack webhook.

--- a/docs/reference/api/alerts.md
+++ b/docs/reference/api/alerts.md
@@ -1,0 +1,197 @@
+---
+title: "Alerts Endpoint"
+description: "REST endpoint returning the conditions in a simplyblock cluster that currently need an operator, with suppression of operator-initiated states and Slack integration."
+weight: 20100
+---
+
+The cluster event log is a journal. It records what happened, keeps it, and never retracts anything. Answering
+*"what is wrong right now"* from it means reading the whole history and working out which entries still apply.
+
+The alerts endpoint answers that question directly. It returns the conditions that are true at this moment,
+suppresses the ones an operator caused on purpose, and removes each entry as soon as it stops being true.
+
+```plain title="Endpoint"
+GET /api/v2/clusters/<CLUSTER_UUID>/alerts/
+```
+
+Authorization is the standard cluster header described in [API / Developer SDK](index.md).
+
+## Getting the Current Alerts
+
+By default, the endpoint returns only what is wrong now. Every entry has `status: firing`.
+
+```bash title="What is wrong right now"
+curl -H "Authorization: $CLUSTER_UUID $CLUSTER_SECRET" \
+  "https://$MGMT_IP/api/v2/clusters/$CLUSTER_UUID/alerts/"
+```
+
+```json title="Response"
+[
+  {
+    "id": "node_offline:08820485-de07-42b7-b43e-1d96113db000",
+    "kind": "node_offline",
+    "severity": "critical",
+    "status": "firing",
+    "message": "node worker-3 offline",
+    "cluster_id": "d6e9a1c4-...",
+    "node_id": "08820485-de07-42b7-b43e-1d96113db000",
+    "device_id": null,
+    "since": "2026-09-12 13:46:13.930000+00:00",
+    "first_seen": "2026-09-12 13:46:19.210000+00:00",
+    "resolved_at": null,
+    "details": {"status": "offline"}
+  }
+]
+```
+
+An empty array means nothing is wrong.
+
+The `id` is derived from the alert kind and the object it concerns, so it is stable across polls. A consumer can
+deduplicate on it without keeping any state of its own. Critical alerts sort before warnings, and firing alerts
+before resolved ones.
+
+## Query Parameters
+
+| Parameter         | Type                 | Default | Description                                                                            |
+|-------------------|----------------------|---------|----------------------------------------------------------------------------------------|
+| `severity`        | `critical`/`warning` | all     | Return only alerts of this severity.                                                   |
+| `status`          | `firing`/`resolved`  | all     | Return only alerts in this state.                                                      |
+| `history`         | boolean              | `false` | Also return alerts that have already resolved.                                         |
+| `history_seconds` | integer ≥ 1          | —       | Limit the history to alerts resolved within this many seconds. Implies `history=true`. |
+
+```bash title="Only the page-worthy ones"
+curl ... "/api/v2/clusters/$CLUSTER_UUID/alerts/?severity=critical"
+```
+
+```bash title="Everything, including what has already resolved"
+curl ... "/api/v2/clusters/$CLUSTER_UUID/alerts/?history=true"
+```
+
+```bash title="What happened in the last hour"
+curl ... "/api/v2/clusters/$CLUSTER_UUID/alerts/?history_seconds=3600"
+```
+
+```bash title="Only the things that cleared in the last hour"
+curl ... "/api/v2/clusters/$CLUSTER_UUID/alerts/?history_seconds=3600&status=resolved"
+```
+
+History is bounded: resolved alerts are kept for seven days, and at most 200 entries per cluster. For anything
+older, the cluster event log holds an `ALERT_RAISED` and an `ALERT_RESOLVED` entry for every transition.
+
+## Alert Kinds
+
+| Kind                                    | Severity | Fires when                                                        | Stays quiet when                                           |
+|-----------------------------------------|----------|-------------------------------------------------------------------|------------------------------------------------------------|
+| `node_offline`                          | critical | A storage node is offline.                                        | An operator stopped it with `storage-node shutdown`.       |
+| `node_restart_hung`                     | critical | A node has been restarting for more than three minutes.           | —                                                          |
+| `node_unavailable`                      | critical | A storage node is unreachable.                                    | —                                                          |
+| `node_down`                             | critical | A node has been down for more than 60 seconds.                    | Another node is restarting or shutting down.               |
+| `cluster_degraded`                      | critical | The cluster is degraded.                                          | A node was stopped by an operator.                         |
+| `cluster_suspended`                     | critical | The cluster is suspended.                                         | Never. A suspended cluster serves no I/O.                  |
+| `device_unavailable`                    | critical | A device on an **online** node is unavailable, failed or removed. | The operator removed it, or the node itself is not online. |
+| `node_jc_compression_error`             | critical | The journal reported a compression error.                         | —                                                          |
+| `node_unrecoverable_io_error`           | critical | An unrecoverable I/O error (a *distr error* in the event log).    | —                                                          |
+| `node_unrecoverable_jc_error`           | critical | An unrecoverable journal error.                                   | —                                                          |
+| `api_slow`                              | critical | Mean control plane API request latency above 15 seconds.          | —                                                          |
+| `cluster_capacity_critical`             | warning  | Absolute capacity passed `--cap-crit`.                            | —                                                          |
+| `cluster_provisioned_capacity_critical` | warning  | Provisioned capacity passed `--prov-cap-crit`.                    | —                                                          |
+
+### Why Operator-Initiated States Are Not Alerts
+
+Every condition in the table above is also produced deliberately, many times a day, by ordinary operations. An
+operator shuts a node down, so the node is offline and the cluster is degraded. A node restarts, so its peers go
+briefly down. An operator pulls a device, so the device is unavailable.
+
+An alert feed that fires on those is noise, and a noisy feed is one nobody reads. The endpoint therefore
+suppresses each of them, using the record of the operator's intent rather than guessing:
+
+- A node stopped with `{{ cliname }} storage-node shutdown` is marked as deliberately stopped until it comes back
+  online. Neither the node nor the cluster degradation it causes raises an alert.
+- A device removed with `{{ cliname }} storage-node remove-device` is marked as administratively removed.
+- Device alerts are raised **only for online nodes**. A graceful shutdown marks every device on the node
+  unavailable on purpose, and an offline node cannot report anything meaningful about its devices. In those cases
+  the node is the alert, and one node operation must not become a storm of device alerts.
+
+A cluster in `suspended` is the deliberate exception: it is not serving I/O, so it alerts whatever the cause.
+
+## Alerts Resolve
+
+An alert that only ever appears is a problem report with no end. Whoever was notified has no way to learn from
+the same channel that the problem is over.
+
+Each alert therefore has two transitions, and both are recorded in the cluster event log:
+
+| Event            | Level               | Written when              |
+|------------------|---------------------|---------------------------|
+| `ALERT_RAISED`   | Critical or Warning | A condition starts.       |
+| `ALERT_RESOLVED` | Info                | The same condition stops. |
+
+Only transitions are written. A condition that persists for a week produces two event log entries, not one per
+poll.
+
+## Sending Alerts to Slack
+
+Simplyblock clusters already send Grafana alerts to Slack through the contact point configured at cluster
+creation, described in [Alerting](../../kubernetes/operations/monitoring/alerts.md). That covers the pre-defined
+metric and event log rules. To get the alerts endpoint itself into Slack, use one of the following.
+
+### Option 1: Grafana Event Log Rules
+
+The endpoint writes `ALERT_RAISED` and `ALERT_RESOLVED` into the cluster event log, and Grafana can already read
+that log through a REST data source. Enable the event log rules once, from any management node:
+
+```bash title="Enable the event log alert rules"
+{{ cliname }} cluster event-alerts <CLUSTER_UUID> --enable
+```
+
+Alerts then reach the same Slack channel as every other Grafana alert, and no additional component is needed.
+Grafana downloads a plugin on the next restart, so it is briefly unavailable.
+
+### Option 2: Poll the Endpoint and Post to a Slack Webhook
+
+To work with the alert objects themselves, create a Slack
+[Incoming Webhook](https://api.slack.com/messaging/webhooks){:target="_blank" rel="noopener"} for the target
+channel and poll the endpoint. Each alert carries a stable `id`, so posting only the ones not already reported is
+a set difference.
+
+```bash title="/usr/local/bin/simplyblock-slack-alerts.sh"
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CLUSTER_UUID:?}" "${CLUSTER_SECRET:?}" "${MGMT_IP:?}" "${SLACK_WEBHOOK_URL:?}"
+STATE=/var/lib/simplyblock/alerts.seen
+mkdir -p "$(dirname "$STATE")"; touch "$STATE"
+
+curl -fsS -H "Authorization: $CLUSTER_UUID $CLUSTER_SECRET" \
+  "https://$MGMT_IP/api/v2/clusters/$CLUSTER_UUID/alerts/?severity=critical" \
+  | jq -r '.[] | "\(.id)\t\(.message)"' > /tmp/alerts.now
+
+# New alerts: firing now, not reported last time.
+comm -13 <(sort "$STATE") <(sort /tmp/alerts.now) | while IFS=$'\t' read -r id message; do
+  jq -n --arg t ":rotating_light: $message" '{text: $t}' \
+    | curl -fsS -X POST -H 'Content-Type: application/json' -d @- "$SLACK_WEBHOOK_URL"
+done
+
+# Resolved alerts: reported last time, gone now.
+comm -23 <(sort "$STATE") <(sort /tmp/alerts.now) | while IFS=$'\t' read -r id message; do
+  jq -n --arg t ":white_check_mark: resolved: $message" '{text: $t}' \
+    | curl -fsS -X POST -H 'Content-Type: application/json' -d @- "$SLACK_WEBHOOK_URL"
+done
+
+mv /tmp/alerts.now "$STATE"
+```
+
+Run it on a timer, for example, every minute:
+
+```bash title="Run every minute"
+*/1 * * * * CLUSTER_UUID=... CLUSTER_SECRET=... MGMT_IP=... SLACK_WEBHOOK_URL=... /usr/local/bin/simplyblock-slack-alerts.sh
+```
+
+!!! note
+    Keep the Slack webhook URL out of the crontab itself. Anyone who can read it can post to the channel. Put it
+    in a root-owned environment file and source it from the script.
+
+!!! tip
+    A poll interval of 30 to 60 seconds is a good default. The endpoint evaluates the cluster state on each
+    request, and its alert lifecycle advances when it is polled, so a very long interval delays both the alert
+    and its resolution.

--- a/docs/reference/limits.md
+++ b/docs/reference/limits.md
@@ -32,6 +32,36 @@ Notes on what counts against the limits:
 - When volume placement finds no node below its subsystem limit, volume creation fails with
   `No nodes found with enough resources to create the LVol`.
 
+## Hard Per-Object Limits
+
+Independent of the per-node limits, single objects are bounded in size and in how many dependants they may have:
+
+| Limit                | Value  | Applies to                                            |
+|----------------------|-------:|-------------------------------------------------------|
+| Volume size          | 70 TiB | Volume creation, resize, and clone with `--size`      |
+| Snapshots per volume | 100    | Active (non-deleted) snapshots taken from one volume  |
+| Clones per snapshot  | 500    | Active (non-deleted) clones created from one snapshot |
+
+A volume and its snapshots form one blob chain, and every snapshot deepens the chain that reads of that volume
+and of its clones must walk. The snapshot and clone limits bound that chain.
+
+```plain title="Per-object limit errors"
+Volume size 80.0 TiB exceeds the maximum of 70.0 TiB per volume
+Snapshot limit reached for volume <VOLUME_ID>: 100 active snapshots; the hard limit is 100 per volume. Delete snapshots before creating more
+Clone limit reached for snapshot <SNAPSHOT_ID>: 500 active clones; the hard limit is 500 per snapshot
+```
+
+Notes:
+
+- The volume size limit applies to the **provisioned** size. It does not cap `--max-size`, the growth ceiling of a
+  thin-provisioned volume, because the command line and the CSI driver pass a large default there when no value is
+  given. Growth is bounded where it happens instead, so a resize beyond the limit is rejected.
+- Internal snapshots taken by replication and volume migration are exempt from the snapshot limit, so a volume at
+  the limit can still be replicated and migrated. They are transient and removed by the operation that created them.
+- Every limit that refuses an operation also raises a warning in the cluster event log, so a volume that silently
+  fails to appear can be traced. Repeated refusals of the same limit on the same object are collapsed, because a
+  retrying client would otherwise fill the log.
+
 ## Configured Subsystem Limit per Node
 
 The 75-subsystem ceiling applies on top of the per-node configured maximum, set at host configuration time:
@@ -56,6 +86,11 @@ ceiling of 50:
 
 When a shared subsystem is full, the next volume automatically starts a new subsystem (which then counts against
 the node's subsystem limit).
+
+A shared subsystem belongs to exactly one storage pool. A namespaced volume only ever joins a subsystem whose
+volumes all belong to its own pool, and a pool fills one of its subsystems completely before a new one is opened.
+Volumes of two different pools therefore never share an NVMe-oF subsystem, which keeps a host connection to one
+pool from exposing another pool's namespaces.
 
 ## vCPU-Dependent Limits
 


### PR DESCRIPTION
Development docs for two things that shipped in R26.3: the hard per-object limits, and the new alerts endpoint.

## `reference/limits.md`

Adds the per-object limits the control plane now enforces on every create and resize path, with the error text each one produces:

| Limit | Value |
|---|---|
| Volume size | 70 TiB |
| Snapshots per volume | 100 |
| Clones per snapshot | 500 |

The notes cover the parts that are easy to get wrong: the size limit applies to the provisioned size and deliberately does **not** cap `--max-size`, the thin growth ceiling that the CLI and the CSI driver fill with a large default; replication and migration snapshots are exempt, so a volume at the snapshot limit can still be replicated and migrated; and every refusal is now recorded in the cluster event log, so a volume that silently fails to appear can be traced.

The namespaces-per-subsystem section gains the pool rule: a shared subsystem belongs to exactly one storage pool, a pool fills one of its subsystems before opening another, and volumes of two pools never share a subsystem. That last point is the one that matters operationally, since it keeps a host connection to one pool from reaching another pool's namespaces.

## `reference/api/alerts.md` (new)

`GET /api/v2/clusters/<CLUSTER_UUID>/alerts/`. Covers the response shape, the four query parameters (`severity`, `status`, `history`, `history_seconds`), and all thirteen alert kinds with what each fires on and what suppresses it.

The section on why operator-initiated states are not alerts is the one worth reviewing. It is the point an alert feed lives or dies on: every condition in the list is also produced deliberately many times a day, and a feed that fires when somebody shuts a node down is a feed nobody reads. The page says which record proves the operator's intent in each case.

It also documents that alerts resolve, and the `ALERT_RAISED` / `ALERT_RESOLVED` pair written to the event log on each transition.

## Getting alerts into Slack

Two routes, both documented on the new page:

1. **Grafana event log rules** (`cluster event-alerts --enable`), which reuse the Slack contact point already configured at cluster creation. No new component.
2. **Poll the endpoint** and post to an incoming webhook, with a worked script that reports new and cleared alerts by diffing the stable alert ids.

Both `monitoring/alerts.md` pages now point at the endpoint.

## Checks

`scripts/quality-gate.sh` reports no errors on any of the four touched files. The failures it still reports are pre-existing on `main`: the generated CLI reference link targets, `io-stats.md`, `openapi.json`, and the terminology errors in `known-issues.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
